### PR TITLE
Feat differentiability and performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*Manifest*.toml

--- a/Project.toml
+++ b/Project.toml
@@ -39,4 +39,4 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DelimitedFiles", "ForwardDiff", "Pkg", "Zygote"]
+test = ["Test", "DelimitedFiles", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -35,7 +35,8 @@ julia = "1.10, 1.11, 1.12"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DelimitedFiles", "ForwardDiff", "Zygote"]
+test = ["Test", "DelimitedFiles", "ForwardDiff", "Pkg", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -13,8 +13,16 @@ SatelliteToolboxLegendre = "7fa26607-a272-47b2-9aa2-a6c1d419d9d2"
 SatelliteToolboxTransformations = "6b019ec1-7a1e-4f04-96c7-a9db1ca5514d"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+[weakdeps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[extensions]
+SatelliteToolboxGeomagneticModelsZygoteExt = ["ForwardDiff", "Zygote"]
+
 [compat]
 DelimitedFiles = "1.9"
+ForwardDiff = "1"
 LinearAlgebra = "1.10"
 ReferenceFrameRotations = "3"
 SatelliteToolboxBase = "1.1"
@@ -22,6 +30,7 @@ SatelliteToolboxLegendre = "1"
 SatelliteToolboxTransformations = "1"
 StaticArrays = "1"
 Test = "1.10"
+Zygote = "0.7"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -34,8 +34,11 @@ Zygote = "0.7"
 julia = "1.10, 1.11, 1.12"
 
 [extras]
+AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DelimitedFiles"]
+test = ["Test", "AllocCheck", "Aqua", "DelimitedFiles", "ForwardDiff", "JET", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -18,20 +18,20 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [extensions]
-SatelliteToolboxGeomagneticModelsZygoteExt = ["ForwardDiff", "Zygote"]
+SatelliteToolboxGeomagneticFieldZygoteExt = ["ForwardDiff", "Zygote"]
 
 [compat]
 DelimitedFiles = "1.9"
 ForwardDiff = "1"
-LinearAlgebra = "1.10"
+LinearAlgebra = "1"
 ReferenceFrameRotations = "3"
 SatelliteToolboxBase = "1.1"
 SatelliteToolboxLegendre = "1"
 SatelliteToolboxTransformations = "1"
 StaticArrays = "1"
-Test = "1.10"
+Test = "1"
 Zygote = "0.7"
-julia = "1.10"
+julia = "1.10, 1.11, 1.12"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/Project.toml
+++ b/Project.toml
@@ -34,11 +34,8 @@ Zygote = "0.7"
 julia = "1.10, 1.11, 1.12"
 
 [extras]
-AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "AllocCheck", "Aqua", "DelimitedFiles", "ForwardDiff", "JET", "Zygote"]
+test = ["Test", "DelimitedFiles", "ForwardDiff", "Zygote"]

--- a/ext/SatelliteToolboxGeomagneticFieldZygoteExt.jl
+++ b/ext/SatelliteToolboxGeomagneticFieldZygoteExt.jl
@@ -24,10 +24,10 @@ function ChainRulesCore.rrule(
     ::Val{:geocentric};
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
-    verbosity::Val{verbose} = Val(false),
+    verbose::Val{verbosity} = Val(false),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-) where {verbose}
+) where {verbosity}
 
     y = igrf(
         date,
@@ -37,7 +37,7 @@ function ChainRulesCore.rrule(
         Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
-        verbosity = verbosity,
+        verbose = verbose,
         P = P,
         dP = dP,
     )
@@ -52,7 +52,7 @@ function ChainRulesCore.rrule(
                 Val(:geocentric);
                 max_degree = max_degree,
                 show_warnings = show_warnings,
-                verbosity = verbosity,
+                verbose = verbose,
             ),
             [date; r; λ_gc; Ω]
         )

--- a/ext/SatelliteToolboxGeomagneticFieldZygoteExt.jl
+++ b/ext/SatelliteToolboxGeomagneticFieldZygoteExt.jl
@@ -1,13 +1,14 @@
 ## Description #############################################################################
 #
-# Zygote Extension for the SatelliteToolboxGeomagneticModels.jl package. Needed since igrf
+# Zygote Extension for the SatelliteToolboxGeomagneticField.jl package. Needed since igrf
 # is mutating and changing that would require a large rework. Instead use ForwardDiff for this function instead.
 #
 ############################################################################################
 
-module SatelliteToolboxGeomagneticModelsZygoteExt
+module SatelliteToolboxGeomagneticFieldZygoteExt
 
-using SatelliteToolboxGeomagneticModels
+using SatelliteToolboxGeomagneticField
+using SatelliteToolboxGeomagneticField: _IGRF_MAX_DEGREE
 
 using Zygote: NoTangent
 using Zygote.ChainRulesCore: ChainRulesCore
@@ -15,21 +16,25 @@ using Zygote.ChainRulesCore: ChainRulesCore
 using ForwardDiff
 
 function ChainRulesCore.rrule(
-    ::typeof(GeomagneticModels.igrf),
+    ::typeof(igrf),
     date::Number,
-    r::AbstractVector{V},
-    time::Number;
+    r::Number,
+    λ_gc::Number,
+    Ω::Number,
+    ::Val{:geocentric};
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
     verbosity::Val{verbose} = Val(false),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-) where {V<:Number, verbose}
+) where {verbose}
 
-    y = GeomagneticModels.igrf(
-        model,
+    y = igrf(
+        date,
         r,
-        time;
+        λ_gc,
+        Ω,
+        Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
         verbosity = verbosity,
@@ -39,27 +44,26 @@ function ChainRulesCore.rrule(
 
     function _igrf_pullback(Δ)
         jac = ForwardDiff.jacobian(
-            (x) -> GeomagneticModels.igrf(
-                date,
-                x[1:3],
-                x[4];
+            (x) -> igrf(
+                x[1],
+                x[2],
+                x[3],
+                x[4],
+                Val(:geocentric);
                 max_degree = max_degree,
                 show_warnings = show_warnings,
                 verbosity = verbosity,
-                P = P,
-                dP = dP,
             ),
-            [r; time]
+            [date; r; λ_gc; Ω]
         )
 
         vjp = Δ' * jac
 
-        return (NoTangent(), NoTangent(), vjp[1:3], vjp[4], (NoTangent(), NoTangent(), NoTangent()))
-
+        return (NoTangent(), vjp[1], vjp[2], vjp[3], vjp[4], NoTangent())
     end
 
     return y, _igrf_pullback
 
-end 
+end
 
 end

--- a/ext/SatelliteToolboxGeomagneticModelsZygoteExt.jl
+++ b/ext/SatelliteToolboxGeomagneticModelsZygoteExt.jl
@@ -1,0 +1,65 @@
+## Description #############################################################################
+#
+# Zygote Extension for the SatelliteToolboxGeomagneticModels.jl package. Needed since igrf
+# is mutating and changing that would require a large rework. Instead use ForwardDiff for this function instead.
+#
+############################################################################################
+
+module SatelliteToolboxGeomagneticModelsZygoteExt
+
+using SatelliteToolboxGeomagneticModels
+
+using Zygote: NoTangent
+using Zygote.ChainRulesCore: ChainRulesCore
+
+using ForwardDiff
+
+function ChainRulesCore.rrule(
+    ::typeof(GeomagneticModels.igrf),
+    date::Number,
+    r::AbstractVector{V},
+    time::Number;
+    max_degree::Int = _IGRF_MAX_DEGREE,
+    show_warnings::Bool = true,
+    verbosity::Val{verbose} = Val(false),
+    P::Union{Nothing, AbstractMatrix} = nothing,
+    dP::Union{Nothing, AbstractMatrix} = nothing
+) where {V<:Number, verbose}
+
+    y = GeomagneticModels.igrf(
+        model,
+        r,
+        time;
+        max_degree = max_degree,
+        show_warnings = show_warnings,
+        verbosity = verbosity,
+        P = P,
+        dP = dP,
+    )
+
+    function _igrf_pullback(Δ)
+        jac = ForwardDiff.jacobian(
+            (x) -> GeomagneticModels.igrf(
+                date,
+                x[1:3],
+                x[4];
+                max_degree = max_degree,
+                show_warnings = show_warnings,
+                verbosity = verbosity,
+                P = P,
+                dP = dP,
+            ),
+            [r; time]
+        )
+
+        vjp = Δ' * jac
+
+        return (NoTangent(), NoTangent(), vjp[1:3], vjp[4], (NoTangent(), NoTangent(), NoTangent()))
+
+    end
+
+    return y, _igrf_pullback
+
+end 
+
+end

--- a/src/dipole/dipole.jl
+++ b/src/dipole/dipole.jl
@@ -43,7 +43,7 @@ function geomagnetic_dipole_field(r_e::AbstractVector{T}, year::Number = 2020) w
     r = norm(r_e)
 
     # Compute the unitary vector that points to the desired direction.
-    er_e = SVector{3, T}(r_e) / r
+    er_e = SVector{3, T}(r_e[1], r_e[2], r_e[3]) / r
 
     # Compute the geomagnetic field vector [nT].
     B_e = (3er_e * er_e' - I) * k₀_e * T(1e9) / r^3

--- a/src/igrf/igrf.jl
+++ b/src/igrf/igrf.jl
@@ -92,9 +92,10 @@ function igrfd(
     Ω::Number;
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
+    verbosity::Val{verbose} = Val(true),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-)
+) where {verbose}
     return igrfd(
         date,
         r,
@@ -103,6 +104,7 @@ function igrfd(
         Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
+        verbosity = verbosity,
         P = P,
         dP = dP
     )
@@ -116,9 +118,10 @@ function igrfd(
     ::Val{:geocentric};
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
+    verbosity::Val{verbose} = Val(true),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-) where {T1<:Number, T2<:Number, T3<:Number}
+) where {T1<:Number, T2<:Number, T3<:Number, verbose}
 
     T = promote_type(T1, T2, T3) |> float
 
@@ -139,6 +142,7 @@ function igrfd(
         Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
+        verbosity = verbosity,
         P = P,
         dP = dP
     )
@@ -152,9 +156,10 @@ function igrfd(
     ::Val{:geodetic};
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
+    verbosity::Val{verbose} = Val(true),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-) where {T1<:Number, T2<:Number, T3<:Number}
+) where {T1<:Number, T2<:Number, T3<:Number, verbose}
 
     T = promote_type(T1, T2, T3) |> float
 
@@ -247,9 +252,10 @@ function igrf(
     Ω::Number;
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
+    verbosity::Val{verbose} = Val(false),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-)
+) where {verbose}
     return igrf(
         date,
         r,
@@ -258,6 +264,7 @@ function igrf(
         Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
+        verbosity = verbosity,
         P = P,
         dP = dP
     )
@@ -271,9 +278,10 @@ function igrf(
     ::Val{:geocentric};
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
+    verbosity::Val{verbose} = Val(false),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-) where {T1<:Number, T2<:Number, T3<:Number}
+) where {T1<:Number, T2<:Number, T3<:Number, verbose}
 
     T = promote_type(T1, T2, T3) |> float
 
@@ -297,7 +305,7 @@ function igrf(
 
     # Warn the user that for dates after the year `rel_year` the accuracy maybe reduced.
     if show_warnings && (date > _IGRF_RELIABLE_YEAR)
-        @warn("The magnetic field computed with this IGRF version may be of reduced accuracy for years greater than $_IGRF_RELIABLE_YEAR.")
+        verbose && @warn("The magnetic field computed with this IGRF version may be of reduced accuracy for years greater than $_IGRF_RELIABLE_YEAR.")
     end
 
     # If the `max_degree` is equal or lower than 0, we must clamp it to 1.
@@ -392,9 +400,10 @@ function igrf(
     ::Val{:geodetic};
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
+    verbosity::Val{verbose} = Val(true),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-)
+) where {verbose}
 
     # TODO: This method has a small error (≈ 0.01 nT) compared with the `igrf12syn`.
     # However, the result is exactly the same as the MATLAB function in [3]. Hence, this
@@ -414,6 +423,7 @@ function igrf(
         Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
+        verbosity = verbosity,
         P = P,
         dP = dP
     )

--- a/src/igrf/igrf.jl
+++ b/src/igrf/igrf.jl
@@ -104,7 +104,7 @@ function igrfd(
         Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
-        verbose = verbose,
+        verbose = Val(verbosity),
         P = P,
         dP = dP
     )
@@ -142,7 +142,7 @@ function igrfd(
         Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
-        verbose = verbose,
+        verbose = Val(verbosity),
         P = P,
         dP = dP
     )
@@ -171,6 +171,7 @@ function igrfd(
         Val(:geodetic);
         max_degree = max_degree,
         show_warnings = show_warnings,
+        verbose = Val(verbosity),
         P = P,
         dP = dP
     )
@@ -264,7 +265,7 @@ function igrf(
         Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
-        verbose = verbose,
+        verbose = Val(verbosity),
         P = P,
         dP = dP
     )
@@ -423,7 +424,7 @@ function igrf(
         Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
-        verbose = verbose,
+        verbose = Val(verbosity),
         P = P,
         dP = dP
     )

--- a/src/igrf/igrf.jl
+++ b/src/igrf/igrf.jl
@@ -13,6 +13,14 @@
 export igrf, igrfd
 
 ############################################################################################
+#                                     Helper Functions                                     #
+############################################################################################
+
+function _igrf_coefficient_index(date::Number)
+    return floor(Int, clamp((date - 1900) / 5 + 1, 0, (_IGRF_RELIABLE_YEAR - 1900) / 5))
+end
+
+############################################################################################
 #                                        Functions                                         #
 ############################################################################################
 
@@ -325,7 +333,7 @@ function igrf(
     # Compute the epoch that will be used to obtain the coefficients. This is necessary
     # because the IGRF provides coefficients every 5 years. Between two epochs, those
     # coefficients must be interpolated.
-    idx   = floor(Int, clamp((date - 1900) / 5 + 1, 0, (_IGRF_RELIABLE_YEAR - 1900) / 5))
+    idx = _igrf_coefficient_index(date)
     epoch = 1900 + (idx - 1) * 5
 
     # We must jump the first two columns that are reserved for the degree and order.

--- a/src/igrf/igrf.jl
+++ b/src/igrf/igrf.jl
@@ -13,14 +13,6 @@
 export igrf, igrfd
 
 ############################################################################################
-#                                     Helper Functions                                     #
-############################################################################################
-
-function _igrf_coefficient_index(date::Number)
-    return floor(Int, clamp((date - 1900) / 5 + 1, 0, (_IGRF_RELIABLE_YEAR - 1900) / 5))
-end
-
-############################################################################################
 #                                        Functions                                         #
 ############################################################################################
 
@@ -100,10 +92,10 @@ function igrfd(
     Ω::Number;
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
-    verbosity::Val{verbose} = Val(true),
+    verbose::Val{verbosity} = Val(true),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-) where {verbose}
+) where {verbosity}
     return igrfd(
         date,
         r,
@@ -112,7 +104,7 @@ function igrfd(
         Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
-        verbosity = verbosity,
+        verbose = verbose,
         P = P,
         dP = dP
     )
@@ -126,10 +118,10 @@ function igrfd(
     ::Val{:geocentric};
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
-    verbosity::Val{verbose} = Val(true),
+    verbose::Val{verbosity} = Val(true),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-) where {T1<:Number, T2<:Number, T3<:Number, verbose}
+) where {T1<:Number, T2<:Number, T3<:Number, verbosity}
 
     T = promote_type(T1, T2, T3) |> float
 
@@ -150,7 +142,7 @@ function igrfd(
         Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
-        verbosity = verbosity,
+        verbose = verbose,
         P = P,
         dP = dP
     )
@@ -164,10 +156,10 @@ function igrfd(
     ::Val{:geodetic};
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
-    verbosity::Val{verbose} = Val(true),
+    verbose::Val{verbosity} = Val(true),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-) where {T1<:Number, T2<:Number, T3<:Number, verbose}
+) where {T1<:Number, T2<:Number, T3<:Number, verbosity}
 
     T = promote_type(T1, T2, T3) |> float
 
@@ -260,10 +252,10 @@ function igrf(
     Ω::Number;
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
-    verbosity::Val{verbose} = Val(false),
+    verbose::Val{verbosity} = Val(true),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-) where {verbose}
+) where {verbosity}
     return igrf(
         date,
         r,
@@ -272,7 +264,7 @@ function igrf(
         Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
-        verbosity = verbosity,
+        verbose = verbose,
         P = P,
         dP = dP
     )
@@ -286,10 +278,10 @@ function igrf(
     ::Val{:geocentric};
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
-    verbosity::Val{verbose} = Val(false),
+    verbose::Val{verbosity} = Val(true),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-) where {T1<:Number, T2<:Number, T3<:Number, verbose}
+) where {T1<:Number, T2<:Number, T3<:Number, verbosity}
 
     T = promote_type(T1, T2, T3) |> float
 
@@ -313,7 +305,7 @@ function igrf(
 
     # Warn the user that for dates after the year `rel_year` the accuracy maybe reduced.
     if show_warnings && (date > _IGRF_RELIABLE_YEAR)
-        verbose && @warn("The magnetic field computed with this IGRF version may be of reduced accuracy for years greater than $_IGRF_RELIABLE_YEAR.")
+        verbosity && @warn("The magnetic field computed with this IGRF version may be of reduced accuracy for years greater than $_IGRF_RELIABLE_YEAR.")
     end
 
     # If the `max_degree` is equal or lower than 0, we must clamp it to 1.
@@ -333,7 +325,7 @@ function igrf(
     # Compute the epoch that will be used to obtain the coefficients. This is necessary
     # because the IGRF provides coefficients every 5 years. Between two epochs, those
     # coefficients must be interpolated.
-    idx = _igrf_coefficient_index(date)
+    idx   = floor(Int, clamp((date - 1900) / 5 + 1, 0, (_IGRF_RELIABLE_YEAR - 1900) / 5))
     epoch = 1900 + (idx - 1) * 5
 
     # We must jump the first two columns that are reserved for the degree and order.
@@ -408,10 +400,10 @@ function igrf(
     ::Val{:geodetic};
     max_degree::Int = _IGRF_MAX_DEGREE,
     show_warnings::Bool = true,
-    verbosity::Val{verbose} = Val(true),
+    verbose::Val{verbosity} = Val(true),
     P::Union{Nothing, AbstractMatrix} = nothing,
     dP::Union{Nothing, AbstractMatrix} = nothing
-) where {verbose}
+) where {verbosity}
 
     # TODO: This method has a small error (≈ 0.01 nT) compared with the `igrf12syn`.
     # However, the result is exactly the same as the MATLAB function in [3]. Hence, this
@@ -431,7 +423,7 @@ function igrf(
         Val(:geocentric);
         max_degree = max_degree,
         show_warnings = show_warnings,
-        verbosity = verbosity,
+        verbose = verbose,
         P = P,
         dP = dP
     )

--- a/src/igrf/igrf.jl
+++ b/src/igrf/igrf.jl
@@ -296,11 +296,11 @@ function igrf(
     end
 
     # Check if the latitude and longitude are valid.
-    if (λ < -π/2) || (λ > π/2)
+    if (λ < -T(π)/2) || (λ > T(π)/2)
         throw(ArgumentError("The latitude must be between -π / 2 and +π / 2 rad."))
     end
 
-    if (Ω < -π) || (Ω > π)
+    if (Ω < -T(π)) || (Ω > T(π))
         throw(ArgumentError("The longitude must be between -π and +π rad."))
     end
 

--- a/test/performance.jl
+++ b/test/performance.jl
@@ -26,6 +26,16 @@ end
         )
     ) == 0
 
+    # THIS IS TO BE REMOVED, NEED TO DETERMINE IF MACOSX CAN BE RESOLVED
+    println(
+        check_allocs(
+            (date, r, λ, Ω, P, dP) -> begin
+                igrf(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
+            end,
+            (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
+        )
+    )
+
     @test length(
         check_allocs(
             (date, h, λ, Ω, P, dP) -> begin

--- a/test/performance.jl
+++ b/test/performance.jl
@@ -1,0 +1,102 @@
+## Description #############################################################################
+#
+# Tests related to performance and memory allocations.
+#
+############################################################################################
+
+@testset "Aqua.jl" begin
+    Aqua.test_all(SatelliteToolboxGeomagneticField; ambiguities=(recursive = false), deps_compat=(check_extras = false))
+end
+
+@testset "JET Testing" begin
+    rep = JET.test_package(SatelliteToolboxGeomagneticField; toplevel_logger=nothing, target_modules=(@__MODULE__,))
+end
+
+# Skip allocation tests on macOS with Julia 1.12+ due to AllocCheck detecting
+# platform-specific runtime calls (jl_get_pgcstack_static) as allocations
+if Sys.isapple() && (VERSION.major == 1 && VERSION.minor >= 12)
+    @warn "Allocation tests skipped on macOS with Julia 1.12+ due to AllocCheck platform limitations"
+else
+    @testset "Allocation Check" begin
+        @test length(
+            check_allocs(
+                (date, r, λ, Ω, P, dP) -> begin
+                    igrf(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
+            )
+        ) == 0
+
+        @test length(
+            check_allocs(
+                (date, h, λ, Ω, P, dP) -> begin
+                    igrf(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
+            )
+        ) == 0
+
+        @test length(
+            check_allocs(
+                (date, r, λ, Ω, P, dP) -> begin
+                    igrfd(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
+            )
+        ) == 0
+
+        @test length(
+            check_allocs(
+                (date, h, λ, Ω, P, dP) -> begin
+                    igrfd(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
+            )
+        ) == 0
+
+        @test length(
+            check_allocs(
+                (r_e, year) -> begin
+                    geomagnetic_dipole_field(r_e, year)
+                end,
+                (SVector{3, Float64}, Float64)
+            )
+        ) == 0
+
+        @test length(
+            check_allocs(
+                (date, r, λ, Ω, P, dP) -> begin
+                    igrf(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
+            )
+        ) == 0
+
+        @test length(
+            check_allocs(
+                (date, h, λ, Ω, P, dP) -> begin
+                    igrf(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
+            )
+        ) == 0
+
+        @test length(
+            check_allocs(
+                (date, r, λ, Ω, P, dP) -> begin
+                    igrfd(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
+            )
+        ) == 0
+
+        @test length(
+            check_allocs(
+                (date, h, λ, Ω, P, dP) -> begin
+                    igrfd(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
+            )
+        ) == 0
+    end
+end

--- a/test/performance.jl
+++ b/test/performance.jl
@@ -8,8 +8,12 @@
     Aqua.test_all(SatelliteToolboxGeomagneticField; ambiguities=(recursive = false), deps_compat=(check_extras = false))
 end
 
-@testset "JET Testing" begin
-    rep = JET.test_package(SatelliteToolboxGeomagneticField; toplevel_logger=nothing, target_modules=(SatelliteToolboxGeomagneticField,))
+if VERSION >= v"1.12"
+    @warn "JET tests skipped on Julia 1.12+ due to JET compatibility limitations"
+else
+    @testset "JET Testing" begin
+        rep = JET.test_package(SatelliteToolboxGeomagneticField; toplevel_logger=nothing, target_modules=(SatelliteToolboxGeomagneticField,))
+    end
 end
 
 @testset "Allocation Check" begin

--- a/test/performance.jl
+++ b/test/performance.jl
@@ -16,95 +16,91 @@ else
     end
 end
 
-@testset "Allocation Check" begin
-    @test length(
-        check_allocs(
-            (date, r, λ, Ω, P, dP) -> begin
-                igrf(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
-            end,
-            (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
-        )
-    ) == 0
+# Skip allocation tests on macOS with Julia 1.12+ due to AllocCheck detecting
+# platform-specific runtime calls (jl_get_pgcstack_static) as allocations
+if Sys.isapple() && VERSION >= v"1.12"
+    @warn "Allocation tests skipped on macOS with Julia 1.12+ due to AllocCheck platform limitations"
+else
+    @testset "Allocation Check" begin
+        @test length(
+            check_allocs(
+                (date, r, λ, Ω, P, dP) -> begin
+                    igrf(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
+            )
+        ) == 0
 
-    # THIS IS TO BE REMOVED, NEED TO DETERMINE IF MACOSX CAN BE RESOLVED
-    println(
-        check_allocs(
-            (date, r, λ, Ω, P, dP) -> begin
-                igrf(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
-            end,
-            (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
-        )
-    )
+        @test length(
+            check_allocs(
+                (date, h, λ, Ω, P, dP) -> begin
+                    igrf(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
+            )
+        ) == 0
 
-    @test length(
-        check_allocs(
-            (date, h, λ, Ω, P, dP) -> begin
-                igrf(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
-            end,
-            (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
-        )
-    ) == 0
+        @test length(
+            check_allocs(
+                (date, r, λ, Ω, P, dP) -> begin
+                    igrfd(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
+            )
+        ) == 0
 
-    @test length(
-        check_allocs(
-            (date, r, λ, Ω, P, dP) -> begin
-                igrfd(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
-            end,
-            (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
-        )
-    ) == 0
+        @test length(
+            check_allocs(
+                (date, h, λ, Ω, P, dP) -> begin
+                    igrfd(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
+            )
+        ) == 0
 
-    @test length(
-        check_allocs(
-            (date, h, λ, Ω, P, dP) -> begin
-                igrfd(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
-            end,
-            (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
-        )
-    ) == 0
+        @test length(
+            check_allocs(
+                (r_e, year) -> begin
+                    geomagnetic_dipole_field(r_e, year)
+                end,
+                (SVector{3, Float64}, Float64)
+            )
+        ) == 0
 
-    @test length(
-        check_allocs(
-            (r_e, year) -> begin
-                geomagnetic_dipole_field(r_e, year)
-            end,
-            (SVector{3, Float64}, Float64)
-        )
-    ) == 0
+        @test length(
+            check_allocs(
+                (date, r, λ, Ω, P, dP) -> begin
+                    igrf(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
+            )
+        ) == 0
 
-    @test length(
-        check_allocs(
-            (date, r, λ, Ω, P, dP) -> begin
-                igrf(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
-            end,
-            (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
-        )
-    ) == 0
+        @test length(
+            check_allocs(
+                (date, h, λ, Ω, P, dP) -> begin
+                    igrf(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
+            )
+        ) == 0
 
-    @test length(
-        check_allocs(
-            (date, h, λ, Ω, P, dP) -> begin
-                igrf(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
-            end,
-            (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
-        )
-    ) == 0
+        @test length(
+            check_allocs(
+                (date, r, λ, Ω, P, dP) -> begin
+                    igrfd(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
+            )
+        ) == 0
 
-    @test length(
-        check_allocs(
-            (date, r, λ, Ω, P, dP) -> begin
-                igrfd(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
-            end,
-            (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
-        )
-    ) == 0
-
-    @test length(
-        check_allocs(
-            (date, h, λ, Ω, P, dP) -> begin
-                igrfd(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
-            end,
-            (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
-        )
-    ) == 0
+        @test length(
+            check_allocs(
+                (date, h, λ, Ω, P, dP) -> begin
+                    igrfd(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
+                end,
+                (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
+            )
+        ) == 0
+    end
 end

--- a/test/performance.jl
+++ b/test/performance.jl
@@ -9,94 +9,88 @@
 end
 
 @testset "JET Testing" begin
-    rep = JET.test_package(SatelliteToolboxGeomagneticField; toplevel_logger=nothing, target_modules=(@__MODULE__,))
+    rep = JET.test_package(SatelliteToolboxGeomagneticField; toplevel_logger=nothing, target_modules=(SatelliteToolboxGeomagneticField,))
 end
 
-# Skip allocation tests on macOS with Julia 1.12+ due to AllocCheck detecting
-# platform-specific runtime calls (jl_get_pgcstack_static) as allocations
-if Sys.isapple() && (VERSION.major == 1 && VERSION.minor >= 12)
-    @warn "Allocation tests skipped on macOS with Julia 1.12+ due to AllocCheck platform limitations"
-else
-    @testset "Allocation Check" begin
-        @test length(
-            check_allocs(
-                (date, r, λ, Ω, P, dP) -> begin
-                    igrf(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
-                end,
-                (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
-            )
-        ) == 0
+@testset "Allocation Check" begin
+    @test length(
+        check_allocs(
+            (date, r, λ, Ω, P, dP) -> begin
+                igrf(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
+            end,
+            (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
+        )
+    ) == 0
 
-        @test length(
-            check_allocs(
-                (date, h, λ, Ω, P, dP) -> begin
-                    igrf(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
-                end,
-                (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
-            )
-        ) == 0
+    @test length(
+        check_allocs(
+            (date, h, λ, Ω, P, dP) -> begin
+                igrf(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
+            end,
+            (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
+        )
+    ) == 0
 
-        @test length(
-            check_allocs(
-                (date, r, λ, Ω, P, dP) -> begin
-                    igrfd(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
-                end,
-                (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
-            )
-        ) == 0
+    @test length(
+        check_allocs(
+            (date, r, λ, Ω, P, dP) -> begin
+                igrfd(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
+            end,
+            (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
+        )
+    ) == 0
 
-        @test length(
-            check_allocs(
-                (date, h, λ, Ω, P, dP) -> begin
-                    igrfd(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
-                end,
-                (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
-            )
-        ) == 0
+    @test length(
+        check_allocs(
+            (date, h, λ, Ω, P, dP) -> begin
+                igrfd(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
+            end,
+            (Float64, Float64, Float64, Float64, Matrix{Float64}, Matrix{Float64})
+        )
+    ) == 0
 
-        @test length(
-            check_allocs(
-                (r_e, year) -> begin
-                    geomagnetic_dipole_field(r_e, year)
-                end,
-                (SVector{3, Float64}, Float64)
-            )
-        ) == 0
+    @test length(
+        check_allocs(
+            (r_e, year) -> begin
+                geomagnetic_dipole_field(r_e, year)
+            end,
+            (SVector{3, Float64}, Float64)
+        )
+    ) == 0
 
-        @test length(
-            check_allocs(
-                (date, r, λ, Ω, P, dP) -> begin
-                    igrf(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
-                end,
-                (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
-            )
-        ) == 0
+    @test length(
+        check_allocs(
+            (date, r, λ, Ω, P, dP) -> begin
+                igrf(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
+            end,
+            (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
+        )
+    ) == 0
 
-        @test length(
-            check_allocs(
-                (date, h, λ, Ω, P, dP) -> begin
-                    igrf(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
-                end,
-                (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
-            )
-        ) == 0
+    @test length(
+        check_allocs(
+            (date, h, λ, Ω, P, dP) -> begin
+                igrf(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
+            end,
+            (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
+        )
+    ) == 0
 
-        @test length(
-            check_allocs(
-                (date, r, λ, Ω, P, dP) -> begin
-                    igrfd(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
-                end,
-                (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
-            )
-        ) == 0
+    @test length(
+        check_allocs(
+            (date, r, λ, Ω, P, dP) -> begin
+                igrfd(date, r, λ, Ω; P = P, dP = dP, verbose = Val(false))
+            end,
+            (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
+        )
+    ) == 0
 
-        @test length(
-            check_allocs(
-                (date, h, λ, Ω, P, dP) -> begin
-                    igrfd(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
-                end,
-                (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
-            )
-        ) == 0
-    end
+    @test length(
+        check_allocs(
+            (date, h, λ, Ω, P, dP) -> begin
+                igrfd(date, h, λ, Ω, Val(:geodetic); P = P, dP = dP, verbose = Val(false))
+            end,
+            (Float64, Float64, Float64, Float64, LowerTriangularStorage{RowMajor, Float64}, LowerTriangularStorage{RowMajor, Float64})
+        )
+    ) == 0
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,11 @@
 using Test
 
 using DelimitedFiles
-using ForwardDiff
 using LinearAlgebra
 using ReferenceFrameRotations
 using SatelliteToolboxBase: LowerTriangularStorage, RowMajor
 using SatelliteToolboxGeomagneticField
 using StaticArrays
-using Zygote
 
 @testset "IGRF" verbose = true begin
     include("./igrf.jl")
@@ -30,10 +28,13 @@ if isempty(VERSION.prerelease)
     @testset "Performance Tests" verbose = true begin
         include("./performance.jl")
     end
-else
-    @warn "Performance checks not guaranteed to work on julia-nightly, skipping"
-end
 
-@testset "Zygote Extension" verbose = true begin
-    include("./zygote_extension.jl")
+    using ForwardDiff
+    using Zygote
+
+    @testset "Zygote Extension" verbose = true begin
+        include("./zygote_extension.jl")
+    end
+else
+    @warn "Performance checks and differentiation extension not guaranteed to work on julia-nightly, skipping"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,17 @@
 using Test
 
+using AllocCheck
+using Aqua
 using DelimitedFiles
+using ForwardDiff
+using JET
 using LinearAlgebra
 using ReferenceFrameRotations
 using SatelliteToolboxGeomagneticField
+
+using SatelliteToolboxBase: LowerTriangularStorage, RowMajor
 using StaticArrays
+using Zygote
 
 @testset "IGRF" verbose = true begin
     include("./igrf.jl")
@@ -12,4 +19,12 @@ end
 
 @testset "Simplified Dipole Model" verbose = true begin
     include("./dipole.jl")
+end
+
+@testset "Performance" verbose = true begin
+    include("./performance.jl")
+end
+
+@testset "Zygote Extension" verbose = true begin
+    include("./zygote_extension.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,9 @@ if isempty(VERSION.prerelease)
         include("./performance.jl")
     end
 
+    Pkg.add("ForwardDiff")
+    Pkg.add("Zygote")
+    
     using ForwardDiff
     using Zygote
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,9 +7,8 @@ using ForwardDiff
 using JET
 using LinearAlgebra
 using ReferenceFrameRotations
-using SatelliteToolboxGeomagneticField
-
 using SatelliteToolboxBase: LowerTriangularStorage, RowMajor
+using SatelliteToolboxGeomagneticField
 using StaticArrays
 using Zygote
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,7 @@
 using Test
 
-using AllocCheck
-using Aqua
 using DelimitedFiles
 using ForwardDiff
-using JET
 using LinearAlgebra
 using ReferenceFrameRotations
 using SatelliteToolboxBase: LowerTriangularStorage, RowMajor
@@ -20,8 +17,21 @@ end
     include("./dipole.jl")
 end
 
-@testset "Performance" verbose = true begin
-    include("./performance.jl")
+if isempty(VERSION.prerelease)
+    using Pkg
+    Pkg.add("JET")
+    Pkg.add("AllocCheck")
+    Pkg.add("Aqua")
+
+    using JET
+    using AllocCheck
+    using Aqua
+
+    @testset "Performance Tests" verbose = true begin
+        include("./performance.jl")
+    end
+else
+    @warn "Performance checks not guaranteed to work on julia-nightly, skipping"
 end
 
 @testset "Zygote Extension" verbose = true begin

--- a/test/zygote_extension.jl
+++ b/test/zygote_extension.jl
@@ -1,0 +1,74 @@
+## Description #############################################################################
+#
+# Tests for the Zygote/ForwardDiff extension (rrule for igrf geocentric).
+#
+############################################################################################
+
+@testset "Zygote IGRF Geocentric Gradient" begin
+    date = 2020.0
+    r    = 6800e3
+    λ    = 0.45
+    Ω    = -1.34
+
+    function loss_sum(x)
+        B = igrf(x[1], x[2], x[3], x[4], Val(:geocentric); show_warnings = false)
+        return sum(B)
+    end
+
+    g_zyg = Zygote.gradient(loss_sum, [date, r, λ, Ω])[1]
+    g_fwd = ForwardDiff.gradient(loss_sum, [date, r, λ, Ω])
+
+    @test g_zyg ≈ g_fwd
+
+    function loss_norm2(x)
+        B = igrf(x[1], x[2], x[3], x[4], Val(:geocentric); show_warnings = false)
+        return B[1]^2 + B[2]^2 + B[3]^2
+    end
+
+    g_zyg = Zygote.gradient(loss_norm2, [date, r, λ, Ω])[1]
+    g_fwd = ForwardDiff.gradient(loss_norm2, [date, r, λ, Ω])
+
+    @test g_zyg ≈ g_fwd
+end
+
+@testset "Zygote IGRF Geocentric Reduced Degree" begin
+    date = 2020.0
+    r    = 6800e3
+    λ    = 0.30
+    Ω    = 0.80
+
+    function loss_reduced(x)
+        B = igrf(
+            x[1], x[2], x[3], x[4], Val(:geocentric);
+            max_degree = 4,
+            show_warnings = false,
+        )
+        return sum(B)
+    end
+
+    g_zyg = Zygote.gradient(loss_reduced, [date, r, λ, Ω])[1]
+    g_fwd = ForwardDiff.gradient(loss_reduced, [date, r, λ, Ω])
+
+    @test g_zyg ≈ g_fwd
+end
+
+@testset "Zygote IGRF Geocentric Different Locations" begin
+    test_cases = [
+        (2015.0, 7000e3,  0.78, -0.50),
+        (2005.5, 6500e3, -0.30,  2.10),
+        (2025.0, 6900e3,  1.20, -2.80),
+    ]
+
+    for (date, r, λ, Ω) in test_cases
+        function loss(x)
+            B = igrf(x[1], x[2], x[3], x[4], Val(:geocentric); show_warnings = false)
+            return sum(B)
+        end
+
+        x = [date, r, λ, Ω]
+        g_zyg = Zygote.gradient(loss, x)[1]
+        g_fwd = ForwardDiff.gradient(loss, x)
+
+        @test g_zyg ≈ g_fwd
+    end
+end


### PR DESCRIPTION
- Added a small Zygote extension and a couple of small changes to support differentiability (full test suite in the differentiability repo)

- Performance testing via JET, Aqua, and AllocCheck

- Some small changes to remove a few stray allocations on 1.12

- A verbose flag. This is redundant with the show_warnings flag, but the show_warnings flag does not allow the suppression of the warnings at compile time. This can easily be changed and collapsed if desired but I didn't want to introduce a breaking change. Compile time removal of this is important for compiler autodiff like Mooncake and allocation static analysis